### PR TITLE
add require_relatives for builders

### DIFF
--- a/lib/builders/enrollment_builder.rb
+++ b/lib/builders/enrollment_builder.rb
@@ -1,4 +1,5 @@
 require_relative '../csv_parser'
+require_relative '../enrollment'
 
 class EnrollmentBuilder
   include CSVParser

--- a/lib/enrollment_repository.rb
+++ b/lib/enrollment_repository.rb
@@ -1,4 +1,3 @@
-require_relative 'enrollment'
 require_relative './builders/enrollment_builder'
 require 'pry'
 

--- a/lib/statewide_testing_repository.rb
+++ b/lib/statewide_testing_repository.rb
@@ -1,3 +1,5 @@
+require_relative './builders/statewide_test_builder'
+
 class StatewideTestRepository
   attr_reader :data
 


### PR DESCRIPTION
we need to require_relative on our repo's for builders and on our builders for the data objects themselves.  We have a problem with our test_helper file.  It is artificially making us safe for our requires since all files are included there.  we should change that so that we require the files we need for each test ONLY on the test file itself and leave the helper for the truly universal ones.